### PR TITLE
Update Nuke: 12.8

### DIFF
--- a/ios101-project5-tumblr.xcodeproj/project.pbxproj
+++ b/ios101-project5-tumblr.xcodeproj/project.pbxproj
@@ -14,7 +14,10 @@
 		ED59161929BC307E000F25AE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED59161829BC307E000F25AE /* Assets.xcassets */; };
 		ED59161C29BC307E000F25AE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED59161A29BC307E000F25AE /* LaunchScreen.storyboard */; };
 		ED59162429BC4921000F25AE /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED59162329BC4921000F25AE /* Post.swift */; };
-		ED59162929BC50E7000F25AE /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = ED59162829BC50E7000F25AE /* Nuke */; };
+		EDDD50782DC420B400B71C96 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD50772DC420B400B71C96 /* Nuke */; };
+		EDDD507A2DC420B400B71C96 /* NukeExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD50792DC420B400B71C96 /* NukeExtensions */; };
+		EDDD507C2DC420B400B71C96 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD507B2DC420B400B71C96 /* NukeUI */; };
+		EDDD507E2DC420B400B71C96 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD507D2DC420B400B71C96 /* NukeVideo */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,7 +37,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED59162929BC50E7000F25AE /* Nuke in Frameworks */,
+				EDDD507C2DC420B400B71C96 /* NukeUI in Frameworks */,
+				EDDD50782DC420B400B71C96 /* Nuke in Frameworks */,
+				EDDD507A2DC420B400B71C96 /* NukeExtensions in Frameworks */,
+				EDDD507E2DC420B400B71C96 /* NukeVideo in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +95,10 @@
 			);
 			name = "ios101-project5-tumblr";
 			packageProductDependencies = (
-				ED59162829BC50E7000F25AE /* Nuke */,
+				EDDD50772DC420B400B71C96 /* Nuke */,
+				EDDD50792DC420B400B71C96 /* NukeExtensions */,
+				EDDD507B2DC420B400B71C96 /* NukeUI */,
+				EDDD507D2DC420B400B71C96 /* NukeVideo */,
 			);
 			productName = "ios101-project5-tumbler";
 			productReference = ED59160C29BC307D000F25AE /* ios101-project5-tumblr.app */;
@@ -120,7 +129,7 @@
 			);
 			mainGroup = ED59160329BC307D000F25AE;
 			packageReferences = (
-				ED59162729BC50E7000F25AE /* XCRemoteSwiftPackageReference "Nuke" */,
+				EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			productRefGroup = ED59160D29BC307D000F25AE /* Products */;
 			projectDirPath = "";
@@ -370,21 +379,36 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		ED59162729BC50E7000F25AE /* XCRemoteSwiftPackageReference "Nuke" */ = {
+		EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/Nuke";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 12.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		ED59162829BC50E7000F25AE /* Nuke */ = {
+		EDDD50772DC420B400B71C96 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = ED59162729BC50E7000F25AE /* XCRemoteSwiftPackageReference "Nuke" */;
+			package = EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = Nuke;
+		};
+		EDDD50792DC420B400B71C96 /* NukeExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeExtensions;
+		};
+		EDDD507B2DC420B400B71C96 /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeUI;
+		};
+		EDDD507D2DC420B400B71C96 /* NukeVideo */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50762DC420B400B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeVideo;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios101-project5-tumblr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios101-project5-tumblr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "8db810839d2e05d8fa43fe72481467e8e9f47bda8dad613e17d2b9a570e27109",
   "pins" : [
     {
       "identity" : "nuke",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "7f73ceaeacd5df75a7994cd82e165ad9ff1815db",
-        "version" : "9.6.1"
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
### Description

The latest Nuke version has migrated the `loadImage(with:into:)` function from `Nuke` to `NukeExtensions`. The only change from a usage standpoint is using `NukeExtensions` on `import` and when calling the related loadImage function.

```
import NukeExtensions
...

NukeExtensions.loadImage(with: url, into: imageView)
```